### PR TITLE
Correct jump button

### DIFF
--- a/Arcade-MoonPatrol.sv
+++ b/Arcade-MoonPatrol.sv
@@ -105,7 +105,7 @@ localparam CONF_STR = {
 	"-;",
 	"R0,Reset;",
 	"J1,Fire,Jump,Start,Coin;",
-	"jn,A,Start,Select,R;",
+	"jn,A,B,Start,R;",
 	"V,v",`BUILD_DATE
 };
 


### PR DESCRIPTION
Map default keys so jump button is 'B' rather than 'Start', and Start game is 'Start', rather than 'Select'.